### PR TITLE
A couple README fixes for generic addPairwiseEnergy

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Instead, you need to use the generic `addPairwiseEnergy` method like this:
 d = dcrf.DenseCRF(100, 3)  # npoints, nlabels
 
 feats = np.array(...)  # Get the pairwise features from somewhere.
-print(feats.shape)     # -> (100, 3)
+print(feats.shape)     # -> (5, 100) = (feature dimensionality, npoints)
 print(feats.dtype)     # -> dtype('float32')
 
 dcrf.addPairwiseEnergy(feats)


### PR DESCRIPTION
Two things in the documentation of the generic non-2D `addPairwiseEnergy`:
1. The feature matrix needs to have shape `(feature_dimensionality, npoints)`; the example previously had this transposed.
2. The feature dimensionality is not necessarily equal to `nlabels`; I changed it to 5 from 3, because it was confusing for me to have these equal by coincidence in the example.