### PR TITLE
Fix height width order in dense_inference.py example

### DIFF
--- a/dense_inference.py
+++ b/dense_inference.py
@@ -20,7 +20,7 @@ output = sys.argv[3]
 M = labels.max() + 1  # number of labels
 
 # Setup the CRF model
-d = dcrf.DenseCRF2D(img.shape[0], img.shape[1], M)
+d = dcrf.DenseCRF2D(img.shape[1], img.shape[0], M)
 
 # Certainty that the ground truth is correct
 GT_PROB = 0.5


### PR DESCRIPTION
The proper syntax is `dcrf.DenseCRF2D(img.shape[1], img.shape[0], M)`.

This has to do with C-ordering versus Fortran ordering, also known as https://en.wikipedia.org/wiki/Row-major_order .

This bug can be highlighted with the following parameters:

```
d.addPairwiseGaussian(sxy=3, compat=0)
d.addPairwiseBilateral(sxy=3, srgb=5, rgbim=img, compat=50)
````
`(img.shape[0], img.shape[1])` gives:
![image](https://cloud.githubusercontent.com/assets/802153/12224213/bf72275c-b7e2-11e5-8087-bfc376297c0b.png)

Note the straight lines characteristic of a stride misalignement.

On the other hand, `(img.shape[1], img.shape[0])` gives:
![image](https://cloud.githubusercontent.com/assets/802153/12224217/c67476ae-b7e2-11e5-9db2-319b7bc31fc3.png)

This is confirmed by this other Python wrapper for densecrf:

See the order `(D, W, H)` at this line:
https://github.com/mbickel/DenseInferenceWrapper/blob/master/denseinference/lib/libDenseCRF/densecrf.cpp#L139

while the original 2D code is `(H, W)`.