### PR TITLE
Fixed inference example (wrong keyword argument)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ Possible values for the `normalization` argument are:
 Inference
 ---------
 
-The easiest way to do inference is to simply call:
+The easiest way to do inference with 5 iterations is to simply call:
 
 ```python
-Q = d.inference(n_iterations=5)
+Q = d.inference(5)
 ```
 
 And the MAP prediction is then:


### PR DESCRIPTION
Thanks a lot for this repository!
When trying to run the inference example in README.md, it crashed saying that `inference()` doesn't have a keyword argument. I'm just proposing to fix this in the example.