### PR TITLE
Indexing

### DIFF
--- a/pydensecrf/utils.py
+++ b/pydensecrf/utils.py
@@ -28,7 +28,7 @@ def compute_unary(labels, M, GT_PROB=0.5):
 
     U = np.zeros((M, len(labels)), dtype='float32')
     U[:, labels > 0] = n_energy
-    U[labels, np.arange(U.shape[1])] = p_energy
+    U[labels - 1, np.arange(U.shape[1])] = p_energy
     U[:, labels == 0] = u_energy
     return U
 


### PR DESCRIPTION
Due to the special case of '0' indicating no label and being assigned uniform probs, and M being the number of labels not including this I believe the original function was not correct, as the highest label would be out of bounds, and the first label mapped to row 1 of the unary matrix.

The above minor change should fix this, ergo label 1 corresponds to row 1, the number of rows is equal to M, labels go from 1 to M.

(Can show an example if required)