### PR TITLE
Fix Cython build dependency with pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "Cython>=0.22"
+]


### PR DESCRIPTION
Specify Cython as a build system dependency in `pyproject.toml`, so that pip will install Cython before running `setup.py`, according to [PEP 518](https://www.python.org/dev/peps/pep-0518/).
Tested with command `pip install git+https://github.com/li-plus/pydensecrf.git` without having Cython installed.
This really solves Issue #78.