### PR TITLE
Fix for cython 3.0.0 breaking changes by downgrading to 0.29.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools",
     "wheel",
-    "Cython>=0.22"
+    "Cython==0.29.36"
 ]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     url="http://github.com/lucasb-eyer/pydensecrf",
     ext_modules=ext_modules,
     packages=["pydensecrf"],
-    setup_requires=['cython>=0.22'],
+    setup_requires=['cython==0.29.36'],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Closes #123 

A better solution would be to update the package to work with cython 3.0.0 but I'm not familiar with the library. This should at least build now.

To use with docker: 
RUN python -m pip install git+https://github.com/kodalli/pydensecrf.git
