### PR TITLE
Fix pip install error

### DIFF
--- a/pydensecrf/densecrf.pxd
+++ b/pydensecrf/densecrf.pxd
@@ -1,4 +1,4 @@
-from eigen cimport *
+from .eigen cimport *
 
 
 cdef extern from "densecrf/include/labelcompatibility.h":

--- a/pydensecrf/densecrf.pyx
+++ b/pydensecrf/densecrf.pyx
@@ -4,8 +4,8 @@
 
 from numbers import Number
 
-import eigen
-cimport eigen
+import pydensecrf.eigen as eigen
+cimport pydensecrf.eigen as eigen
 
 
 cdef LabelCompatibility* _labelcomp(compat) except NULL:


### PR DESCRIPTION
`pip install .` is throwing errors on my machine because it's not finding requested packages. Using relative import fixes this issue.

Tested on three different machines with both `pip install .` and `pip install pip install git+https://github.com/RogerQi/pydensecrf.git`